### PR TITLE
Split containers files into multiple file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,13 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 
 .PHONY: build-controller-image
 build-controller-image: ## Build controller image.
-	$(CONTAINER_TOOL) build --tag pgbackrest-controller:latest --target pgbackrest-controller \
-		-f containers/pgbackrestPlugin.containers .
+	$(CONTAINER_TOOL) build --tag pgbackrest-controller:latest \
+		-f containers/pgbackrest-controller.container .
 
 .PHONY: build-sidecar-image
 build-sidecar-image: ## Build sidecar image
-	$(CONTAINER_TOOL) build --tag pgbackrest-sidecar:latest --target pgbackrest-sidecar \
-		-f containers/pgbackrestPlugin.containers .
+	$(CONTAINER_TOOL) build --tag pgbackrest-sidecar:latest \
+		-f containers/pgbackrest-sidecar.container .
 
 .PHONY: build-images
 build-images: build-sidecar-image build-controller-image ## Build controller and sidecar images.

--- a/containers/pgbackrest-controller.container
+++ b/containers/pgbackrest-controller.container
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 Dalibo <contact@dalibo.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.25 AS builder
+WORKDIR /app
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download -x
+COPY . ./
+RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 go build -o bin/cnpg-i-pgbackrest ./cmd/
+
+### pgbackrest controller only
+FROM golang:1-alpine AS pgbackrest-controller
+USER 10001:10001
+COPY --from=builder /app/bin/cnpg-i-pgbackrest /app/bin/cnpg-i-pgbackrest
+ENTRYPOINT ["/app/bin/cnpg-i-pgbackrest"]

--- a/containers/pgbackrest-sidecar.container
+++ b/containers/pgbackrest-sidecar.container
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Step 1: build image
 FROM golang:1.25 AS builder
 WORKDIR /app
 COPY go.mod ./
@@ -10,12 +9,6 @@ COPY go.sum ./
 RUN go mod download -x
 COPY . ./
 RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 go build -o bin/cnpg-i-pgbackrest ./cmd/
-
-### pgbackrest controller only
-FROM golang:1-alpine AS pgbackrest-controller
-USER 10001:10001
-COPY --from=builder /app/bin/cnpg-i-pgbackrest /app/bin/cnpg-i-pgbackrest
-ENTRYPOINT ["/app/bin/cnpg-i-pgbackrest"]
 
 ### sidecar definition
 FROM debian:trixie-slim AS pgbackrest-sidecar


### PR DESCRIPTION
This will make publishing easier. We have some duplicate code / build steps, we will see how to avoid that duplication later.