### PR TITLE
Move lock-path conf to repo env & harden plugin container

### DIFF
--- a/internal/instance/backup.go
+++ b/internal/instance/backup.go
@@ -81,9 +81,8 @@ func (b BackupServiceImplementation) Backup(
 	env = append(env, repoDestEnv)
 	contextLogger.Info("using repo", "repo", repoDestEnv)
 	contextLogger.Info("Starting backup")
-	lockFile := "/tmp/pgbackrest-cnpg-plugin.lock"
 	pgb := pgbackrest.NewPgBackrest(env)
-	r, err := pgb.Backup(&lockFile)
+	r, err := pgb.Backup()
 	if err != nil {
 		contextLogger.Error(err, "can't backup")
 		return nil, err

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -280,6 +280,18 @@ func reconcilePodSpec(
 	}
 	containerConfig.Name = "plugin-pgbackrest"
 	containerConfig.ImagePullPolicy = cluster.Spec.ImagePullPolicy
+	containerConfig.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		RunAsNonRoot:             ptr.To(true),
+		Privileged:               ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
 	containerConfig.Env = mergeEnvs(containerConfig.Env, mainEnv, defaultEnv)
 	containerConfig.StartupProbe = baseProbe.DeepCopy()
 	containerConfig.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)

--- a/internal/pgbackrest/api/repo.go
+++ b/internal/pgbackrest/api/repo.go
@@ -146,5 +146,10 @@ type Repository struct {
 }
 
 func (r *Repository) ToEnv() ([]string, error) {
-	return utils.StructToEnvVars(*r, "PGBACKREST_")
+	envConf, err := utils.StructToEnvVars(*r, "PGBACKREST_")
+	if err != nil {
+		return nil, err
+	}
+	envConf = append(envConf, "PGBACKREST_lock-path=/controller/tmp/pgbackrest-cnpg-plugin.lock")
+	return envConf, nil
 }

--- a/internal/pgbackrest/pgbackrest.go
+++ b/internal/pgbackrest/pgbackrest.go
@@ -222,12 +222,9 @@ func (p *PgBackrest) GetWAL(
 	return p.runBackgroundTask(ctx, []string{"archive-get", walName, dstPath}, nil)
 }
 
-func (p *PgBackrest) Backup(lockFile *string) (*BackupInfo, error) {
-	env := make([]string, 2)
+func (p *PgBackrest) Backup() (*BackupInfo, error) {
+	env := make([]string, 1)
 	env = append(env, "PGBACKREST_archive-check=n")
-	if lockFile != nil && (*lockFile) != "" {
-		env = append(env, "PGBACKREST_lock-path="+(*lockFile))
-	}
 	cmd := p.run([]string{"backup"}, env)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -269,11 +266,8 @@ func LatestBackup(backups []BackupInfo) *BackupInfo {
 	return &found
 }
 
-func (p *PgBackrest) Restore(ctx context.Context, lockFile *string) <-chan error {
-	env := make([]string, 2)
+func (p *PgBackrest) Restore(ctx context.Context) <-chan error {
+	env := make([]string, 1)
 	env = append(env, "PGBACKREST_archive-check=n")
-	if lockFile != nil && (*lockFile) != "" {
-		env = append(env, "PGBACKREST_lock-path="+(*lockFile))
-	}
 	return p.runBackgroundTask(ctx, []string{"restore"}, env)
 }

--- a/internal/pgbackrest/pgbackrest_test.go
+++ b/internal/pgbackrest/pgbackrest_test.go
@@ -158,15 +158,12 @@ func TestPushWal(t *testing.T) {
 }
 
 func TestBackup(t *testing.T) {
-	lockFile := "/tmp/test.lock"
 	testCases := []struct {
-		desc     string
-		lockFile *string
-		want     execCalls
+		desc string
+		want execCalls
 	}{
 		{
-			desc:     "run backup",
-			lockFile: &lockFile,
+			desc: "run backup",
 			want: execCalls{
 				execCalls: []fakeExec{
 					{cmdName: "pgbackrest", args: []string{"backup"}},
@@ -181,7 +178,7 @@ func TestBackup(t *testing.T) {
 		fExec := execCalls{}
 		t.Run(tc.desc, func(t *testing.T) {
 			pgb := newPgBackrestWithRunner(nil, fExec.fakeCmdRunner(backup, nil))
-			pgb.Backup(tc.lockFile) //nolint:errcheck
+			pgb.Backup() //nolint:errcheck
 			if !reflect.DeepEqual(fExec, tc.want) {
 				t.Errorf("error want %v, got %v", fExec, tc.want)
 			}

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -45,7 +45,6 @@ func (impl JobHookImpl) Restore(
 ) (*restore.RestoreResponse, error) {
 	contextLogger := log.FromContext(ctx)
 	contextLogger.Info("Start restoring backup")
-	lockFile := "/tmp/pgbackrest-cnpg-plugin.lock"
 	r, err := operator.GetRepo(ctx,
 		req,
 		impl.Client,
@@ -59,7 +58,7 @@ func (impl JobHookImpl) Restore(
 		return nil, err
 	}
 	pgb := pgbackrest.NewPgBackrest(env)
-	errCh := pgb.Restore(ctx, &lockFile)
+	errCh := pgb.Restore(ctx)
 	if err := <-errCh; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The pgBackRest lock file handling is refactored to remove the explicit lockFile parameter from Backup and Restore. The lock-path is now set in the Repository environment via ToEnv(), ensuring a single, consistent source of configuration.

This simplifies the API surface, eliminates redundant code paths, and prevents callers from managing lock file paths manually.