### PR TITLE
Refactor WAL and restore services to drop SpoolDirectory field

### DIFF
--- a/internal/instance/manager.go
+++ b/internal/instance/manager.go
@@ -59,10 +59,9 @@ func Start(ctx context.Context) error {
 		Client:       mgr.GetClient(),
 		InstanceName: podName,
 		// TODO: improve
-		PGDataPath:     viper.GetString("pgdata"),
-		PGWALPath:      path.Join(viper.GetString("pgdata"), "pg_wal"),
-		SpoolDirectory: viper.GetString("spool-directory"),
-		PluginPath:     viper.GetString("plugin-path"),
+		PGDataPath: viper.GetString("pgdata"),
+		PGWALPath:  path.Join(viper.GetString("pgdata"), "pg_wal"),
+		PluginPath: viper.GetString("plugin-path"),
 	}); err != nil {
 		setupLog.Error(err, "unable to create pbacrest plugin runnable/server")
 		return err

--- a/internal/instance/start.go
+++ b/internal/instance/start.go
@@ -17,10 +17,9 @@ import (
 
 // PgbackrestPlugin is the implementation of the PostgreSQL sidecar
 type PgbackrestPluginServer struct {
-	Client         client.Client
-	PGDataPath     string
-	PGWALPath      string
-	SpoolDirectory string
+	Client     client.Client
+	PGDataPath string
+	PGWALPath  string
 	// mutually exclusive with serverAddress
 	PluginPath   string
 	InstanceName string
@@ -30,11 +29,10 @@ type PgbackrestPluginServer struct {
 func (c *PgbackrestPluginServer) Start(ctx context.Context) error {
 	enrich := func(server *grpc.Server) error {
 		wal.RegisterWALServer(server, &wal_pgbackrest.WALSrvImplementation{
-			InstanceName:   c.InstanceName,
-			Client:         c.Client,
-			SpoolDirectory: c.SpoolDirectory,
-			PGDataPath:     c.PGDataPath,
-			PGWALPath:      c.PGWALPath,
+			InstanceName: c.InstanceName,
+			Client:       c.Client,
+			PGDataPath:   c.PGDataPath,
+			PGWALPath:    c.PGWALPath,
 		})
 		backup.RegisterBackupServer(server, BackupServiceImplementation{
 			Client:       c.Client,

--- a/internal/operator/lifecycle.go
+++ b/internal/operator/lifecycle.go
@@ -107,6 +107,7 @@ func staticEnvVarConfig() []corev1.EnvVar {
 		{Name: "PGBACKREST_log-level-file", Value: "off"},
 		{Name: "PGBACKREST_pg1-path", Value: "/var/lib/postgresql/data/pgdata"},
 		{Name: "PGBACKREST_start-fast", Value: "y"},
+		{Name: "PGBACKREST_SPOOL_PATH", Value: "/controller/wal-spool"},
 	}
 }
 

--- a/internal/restore/manager.go
+++ b/internal/restore/manager.go
@@ -57,10 +57,9 @@ func Start(ctx context.Context) error {
 		Client:       mgr.GetClient(),
 		InstanceName: podName,
 		// TODO: improve
-		PGDataPath:     viper.GetString("pgdata"),
-		PGWALPath:      path.Join(viper.GetString("pgdata"), "pg_wal"),
-		SpoolDirectory: viper.GetString("spool-directory"),
-		PluginPath:     viper.GetString("plugin-path"),
+		PGDataPath: viper.GetString("pgdata"),
+		PGWALPath:  path.Join(viper.GetString("pgdata"), "pg_wal"),
+		PluginPath: viper.GetString("plugin-path"),
 	}); err != nil {
 		setupLog.Error(err, "unable to create CNPGI runnable")
 		return err

--- a/internal/restore/restore.go
+++ b/internal/restore/restore.go
@@ -20,7 +20,6 @@ type JobHookImpl struct {
 
 	Client client.Client
 
-	SpoolDirectory       string
 	PgDataPath           string
 	PgWalFolderToSymlink string
 }

--- a/internal/restore/start.go
+++ b/internal/restore/start.go
@@ -17,10 +17,9 @@ import (
 
 // CNPGI is the implementation of the PostgreSQL sidecar
 type CNPGI struct {
-	Client         client.Client
-	PGDataPath     string
-	PGWALPath      string
-	SpoolDirectory string
+	Client     client.Client
+	PGDataPath string
+	PGWALPath  string
 	// mutually exclusive with serverAddress
 	PluginPath   string
 	InstanceName string
@@ -30,15 +29,13 @@ type CNPGI struct {
 func (c *CNPGI) Start(ctx context.Context) error {
 	enrich := func(server *grpc.Server) error {
 		wal.RegisterWALServer(server, &wal_pgbackrest.WALSrvImplementation{
-			InstanceName:   c.InstanceName,
-			Client:         c.Client,
-			SpoolDirectory: c.SpoolDirectory,
-			PGDataPath:     c.PGDataPath,
-			PGWALPath:      c.PGWALPath,
+			InstanceName: c.InstanceName,
+			Client:       c.Client,
+			PGDataPath:   c.PGDataPath,
+			PGWALPath:    c.PGWALPath,
 		})
 		restore.RegisterRestoreJobHooksServer(server, &JobHookImpl{
 			Client:               c.Client,
-			SpoolDirectory:       c.SpoolDirectory,
 			PgDataPath:           c.PGDataPath,
 			PgWalFolderToSymlink: "/var/lib/postgresql/wal/pg_wal",
 		})

--- a/internal/wal/impl.go
+++ b/internal/wal/impl.go
@@ -19,10 +19,9 @@ import (
 
 type WALSrvImplementation struct {
 	wal.UnimplementedWALServer
-	Client         client.Client
-	PGDataPath     string
-	PGWALPath      string
-	SpoolDirectory string
+	Client     client.Client
+	PGDataPath string
+	PGWALPath  string
 	// mutually exclusive with serverAddress
 	PluginPath    string
 	InstanceName  string
@@ -71,9 +70,6 @@ func (w_impl *WALSrvImplementation) Archive(
 		return nil, err
 	}
 	env, err := operator.GetEnvVarConfig(ctx, *repo, w_impl.Client)
-	if w_impl.SpoolDirectory != "" {
-		env = append(env, "PGBACKREST_SPOOL_PATH="+w_impl.SpoolDirectory)
-	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Remove SpoolDirectory from instance, restore, and WAL server structs. We also stop passing spool directory through constructors and gRPC services. And finally configure pgBackRest spool path via PGBACKREST_SPOOL_PATH env var

Ideally we should probably use a specific volume/pvc to store the WAL when archiving.