### PR TITLE
Fix typo in Stanza resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To use this plugin with a **Cluster**, CNPG users must:
   ``` yaml
   ---
   apiVersion: pgbackrest.dalibo.com/v1
-  kind: stanza
+  kind: Stanza
   metadata:
     name: stanza-sample
   spec:


### PR DESCRIPTION
In the example, the resource name is wrong. It must begin with a capital letter, otherwise this error is sent : 

`The stanza "stanza-sample" is invalid: kind: Invalid value: "stanza": must be Stanza`
