### PR TITLE
Fix parameter name in stanza spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To use this plugin with a **Cluster**, CNPG users must:
   ``` yaml
   ---
   apiVersion: pgbackrest.dalibo.com/v1
-  kind: stanza
+  kind: Stanza
   metadata:
     name: stanza-sample
   spec:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To use this plugin with a **Cluster**, CNPG users must:
     name: stanza-sample
   spec:
     stanzaConfiguration:
-      stanza: main
+      name: main
       s3Repositories:
         - bucket: demo
           endpoint: s3.minio.svc.cluster.local


### PR DESCRIPTION
In the example file, there is a error. The field name "stanza" must be replaced by "name".

```
Error from server (BadRequest): error when creating "cluster.yaml": Stanza in version "v1" cannot be handled as a Stanza: strict decoding error: unknown field "spec.stanzaConfiguration.stanza"
```