### PR TITLE
Automatically add cluster name in repo path

### DIFF
--- a/internal/pgbackrest/api/stanza.go
+++ b/internal/pgbackrest/api/stanza.go
@@ -153,7 +153,7 @@ type S3Repository struct {
 	// +optional
 	SecretRef *SecretRef `json:"secretRef,omitempty"`
 
-	// Path where backups and archive are stored.
+	// Path where backups and archives are stored.
 	// +kubebuilder:validation:MinLength=1
 	RepoPath string `json:"repoPath" env:"_PATH"`
 
@@ -266,4 +266,8 @@ func (r *Stanza) ToEnv() ([]string, error) {
 	)
 
 	return envConf, nil
+}
+
+func AppendToRepoPath(r *S3Repository, serverName string) {
+	r.RepoPath = r.RepoPath + "/" + serverName
 }

--- a/test/e2e/internal/pgbackrest/pgbackrest.go
+++ b/test/e2e/internal/pgbackrest/pgbackrest.go
@@ -54,7 +54,7 @@ func NewStanzaConfig(
 						Region:    "us-east-1",
 						VerifyTLS: &verifyTls,
 						UriStyle:  "path",
-						RepoPath:  "/repo01" + name,
+						RepoPath:  "/repo01",
 						RetentionPolicy: pgbackrest.Retention{
 							FullType: "count",
 							Full:     7,


### PR DESCRIPTION
The idea is to append the cluster name (serverName variable) to the REPO_PATH.
Thanks to that, the previous test with restored cluster could be change as well.