### PR TITLE
fix: change LeaderElectionID to avoid conflict

### DIFF
--- a/internal/operator/manager.go
+++ b/internal/operator/manager.go
@@ -60,7 +60,7 @@ func Start(ctx context.Context) error {
 		Metrics:                       metricsServerOptions,
 		HealthProbeBindAddress:        viper.GetString("health-probe-bind-address"),
 		LeaderElection:                true,
-		LeaderElectionID:              "822e3f5c.cnpg.io",
+		LeaderElectionID:              "822e3f5c.pgbackrest.cnpg.io",
 		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {


### PR DESCRIPTION
saw this issue about the LeaderElectionID conflict with barman cloud plugin. changed it to be unique by adding pgbackrest prefix.

this should fix the lease conflict when both plugins are deployed together.

closes #97