### PR TITLE
Handle repo without secrets

### DIFF
--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -241,30 +241,31 @@ func getEnvVarForS3(
 ) ([]string, error) {
 	s3env := make([]string, 0, len(repositories))
 	for i, r := range repositories {
-		sRef := r.SecretRef
-		aKey, err := decodeSecretVal(ctx, c, ns, sRef.AccessKeyIDReference)
-		if err != nil {
-			return nil, err
-		}
-		sKey, err := decodeSecretVal(ctx, c, ns, sRef.SecretAccessKeyReference)
-		if err != nil {
-			return nil, err
-		}
 		prefix := fmt.Sprintf("PGBACKREST_REPO%d_", startId+i)
+		if sRef := r.SecretRef; sRef != nil {
+			aKey, err := decodeSecretVal(ctx, c, ns, sRef.AccessKeyIDReference)
+			if err != nil {
+				return nil, fmt.Errorf("cannot decode S3 secret: %w (missing or invalid)", err)
+			}
+			sKey, err := decodeSecretVal(ctx, c, ns, sRef.SecretAccessKeyReference)
+			if err != nil {
+				return nil, fmt.Errorf("cannot decode S3 key: %w (missing or invalid)", err)
+			}
+			s3env = append(
+				s3env,
+				fmt.Sprintf("%sS3_KEY=%s", prefix, aKey),
+				fmt.Sprintf("%sS3_KEY_SECRET=%s", prefix, sKey),
+			)
+		}
 		if r.Cipher != nil {
 			encKey, err := decodeSecretVal(ctx, c, ns, r.Cipher.PassReference)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("cannot decode cipher secret: %w", err)
 			}
 			s3env = append(s3env, fmt.Sprintf("%sCIPHER_PASS=%s", prefix, encKey))
 		}
 		// build env var names
-		s3env = append(
-			s3env,
-			fmt.Sprintf("%sS3_KEY=%s", prefix, aKey),
-			fmt.Sprintf("%sS3_KEY_SECRET=%s", prefix, sKey),
-			fmt.Sprintf("%sTYPE=%s", prefix, "s3"),
-		)
+		s3env = append(s3env, fmt.Sprintf("%sTYPE=s3", prefix))
 	}
 	return s3env, nil
 }
@@ -278,17 +279,16 @@ func getEnvVarForAzure(
 ) ([]string, error) {
 	azureEnv := make([]string, 0, len(repositories))
 	for i, r := range repositories {
-		sRef := r.SecretRef
-		sKey, err := decodeSecretVal(ctx, c, ns, sRef.KeyReference)
-		if err != nil {
-			return nil, err
-		}
 		prefix := fmt.Sprintf("PGBACKREST_REPO%d_", (startId + i))
-		azureEnv = append(
-			azureEnv,
-			fmt.Sprintf("%sAZURE_KEY=%s", prefix, sKey),
-			fmt.Sprintf("%sTYPE=%s", prefix, "azure"),
-		)
+		if sRef := r.SecretRef; sRef != nil {
+			sKey, err := decodeSecretVal(ctx, c, ns, sRef.KeyReference)
+			if err != nil {
+				return nil, fmt.Errorf("cannot decode Azure secret: %w (missing or invalid)", err)
+			}
+
+			azureEnv = append(azureEnv, fmt.Sprintf("%sAZURE_KEY=%s", prefix, sKey))
+		}
+		azureEnv = append(azureEnv, fmt.Sprintf("%sTYPE=azure", prefix))
 	}
 	return azureEnv, nil
 }

--- a/internal/operator/config_test.go
+++ b/internal/operator/config_test.go
@@ -7,6 +7,7 @@ package operator
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
@@ -126,5 +127,35 @@ func TestGetEnvVarConfig(t *testing.T) {
 		if !slices.Contains(env, e) {
 			t.Errorf("expected env var %v not found in: %v", e, env)
 		}
+	}
+}
+
+func TestGetEnvVarConfig_MissingSecret(t *testing.T) {
+	ctx := context.Background()
+	r := buildRepo()
+
+	// Build client WITHOUT the access-key-secret
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			// only include some secrets, omit one on purpose
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "another-secret-key",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key": []byte("SECRET123"),
+				},
+			},
+		).
+		Build()
+
+	_, err := GetEnvVarConfig(ctx, *r, c)
+	if err == nil {
+		t.Fatalf("expected error when secret is missing, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "secrets \"access-key-secret\" not found") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/operator/role.go
+++ b/internal/operator/role.go
@@ -14,13 +14,15 @@ import (
 
 func getSecrets(stanza apipgbackrest.Stanza, s *stringset.Data) {
 	for _, s3r := range stanza.Spec.Configuration.S3Repositories {
-		akidr := s3r.SecretRef.AccessKeyIDReference
-		akisr := s3r.SecretRef.SecretAccessKeyReference
-		if akidr != nil {
-			s.Put(akidr.Name)
-		}
-		if akisr != nil {
-			s.Put(akisr.Name)
+		if s3r.SecretRef != nil {
+			akidr := s3r.SecretRef.AccessKeyIDReference
+			akisr := s3r.SecretRef.SecretAccessKeyReference
+			if akidr != nil {
+				s.Put(akidr.Name)
+			}
+			if akisr != nil {
+				s.Put(akisr.Name)
+			}
 		}
 		if s3r.Cipher != nil {
 			if pr := s3r.Cipher.PassReference; pr != nil {
@@ -29,8 +31,10 @@ func getSecrets(stanza apipgbackrest.Stanza, s *stringset.Data) {
 		}
 	}
 	for _, azr := range stanza.Spec.Configuration.AzureRepositories {
-		if azk := azr.SecretRef.KeyReference; azk != nil {
-			s.Put(azk.Name)
+		if azr.SecretRef != nil {
+			if azk := azr.SecretRef.KeyReference; azk != nil {
+				s.Put(azk.Name)
+			}
 		}
 	}
 }

--- a/internal/operator/role_test.go
+++ b/internal/operator/role_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Dalibo <contact@dalibo.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+package operator
+
+import (
+	"testing"
+
+	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
+	"github.com/cloudnative-pg/machinery/pkg/stringset"
+	apipgbackrest "github.com/dalibo/cnpg-i-pgbackrest/api/v1"
+	pgbackrest "github.com/dalibo/cnpg-i-pgbackrest/internal/pgbackrest/api"
+)
+
+func TestGetSecrets(t *testing.T) {
+	t.Run("with secrets", func(t *testing.T) {
+		stanza := apipgbackrest.Stanza{
+			Spec: apipgbackrest.StanzaSpec{
+				Configuration: pgbackrest.Stanza{
+					S3Repositories: []pgbackrest.S3Repository{
+						{
+							SecretRef: &pgbackrest.S3SecretRef{
+								AccessKeyIDReference: &machineryapi.SecretKeySelector{
+									LocalObjectReference: machineryapi.LocalObjectReference{
+										Name: "access-key-1",
+									},
+									Key: "key",
+								},
+								SecretAccessKeyReference: &machineryapi.SecretKeySelector{
+									LocalObjectReference: machineryapi.LocalObjectReference{
+										Name: "secret-key-1",
+									},
+									Key: "key",
+								},
+							},
+						},
+					},
+					AzureRepositories: []pgbackrest.AzureRepository{
+						{
+							SecretRef: &pgbackrest.AzureSecretRef{
+								KeyReference: &machineryapi.SecretKeySelector{
+									LocalObjectReference: machineryapi.LocalObjectReference{
+										Name: "azure-key-1",
+									},
+									Key: "key",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		s := stringset.New()
+		getSecrets(stanza, s)
+
+		expected := []string{"access-key-1", "secret-key-1", "azure-key-1"}
+
+		for _, name := range expected {
+			if !s.Has(name) {
+				t.Errorf("expected secret %q to be in set, but it was missing", name)
+			}
+		}
+
+		if s.Len() != len(expected) {
+			t.Errorf("expected %d secrets in set, got %d", len(expected), s.Len())
+		}
+	})
+
+	t.Run("no secrets", func(t *testing.T) {
+		stanza := apipgbackrest.Stanza{
+			Spec: apipgbackrest.StanzaSpec{
+				Configuration: pgbackrest.Stanza{
+					S3Repositories:    []pgbackrest.S3Repository{{SecretRef: nil}},
+					AzureRepositories: []pgbackrest.AzureRepository{{SecretRef: nil}},
+				},
+			},
+		}
+
+		s := stringset.New()
+		getSecrets(stanza, s)
+
+		if s.Len() != 0 {
+			t.Errorf("expected no secrets in set, got %d: %v", s.Len(), s)
+		}
+	})
+}

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
@@ -18,6 +19,9 @@ func GetValueFromSecret(
 	namespace string,
 	secretReference *machineryapi.SecretKeySelector,
 ) ([]byte, error) {
+	if secretReference == nil {
+		return nil, errors.New("secret reference is nil")
+	}
 	secret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretReference.Name}, secret)
 	if err != nil {


### PR DESCRIPTION
It could be useful for workload identity based authentication. This also make our plugin more robust and more explicit about missing secret when referenced.