### PR TITLE
Add info about generated secret for sidecar image

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -103,3 +103,14 @@ spec:
             - name: SIDECAR_EXPORTER_IMAGE
                value: <my_own_image>
 ```
+
+By default, the plugin installation creates a Secret containing the
+image references used by the sidecar containers (and the exporter
+sidecar, when enabled). The controller reads these values through the
+`SIDECAR_IMAGE` and `SIDECAR_EXPORTER_IMAGE`environment variables.
+
+This mechanism allows image references to be managed declaratively by
+the installation manifests while still providing a simple way to
+override them. Users can customize the images either by updating the
+Secret or by explicitly setting the corresponding environment variables
+on the plugin controller Deployment.


### PR DESCRIPTION
Default deployment defines a secret to define what images the sidecars should use. This commit add a few words about those secrets.

close #107